### PR TITLE
Use ubuntu xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "bento/ubuntu-16.04"
   config.ssh.forward_agent = true
   config.vm.network "private_network", ip: "192.168.33.10"
    config.vm.provider "virtualbox" do |vb|

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,8 @@ update-locale LC_ALL=en_US.utf8
 
 apt-get update
 export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set password dialogue
-apt-get install -y git imagemagick mysql-server python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim
-add-apt-repository ppa:brightbox/ruby-ng
-apt-get update
-apt-get install -y ruby2.2 ruby2.2-dev
+apt-get install -y git imagemagick mysql-server python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
 gem install bundler
-curl -sL https://deb.nodesource.com/setup_4.x | bash
-apt-get install -y nodejs
 add-apt-repository ppa:fcwu-tw/ppa
 apt-get update
 apt-get install -y vim

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,14 @@
 update-locale LC_ALL=en_US.utf8
 
 apt-get update
+# We need MySQL 5.6 right now, but since it's not in Xenial package repositories, we need to have this one here in place
+add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty universe'
 export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set password dialogue
 export MYSQL_ROOT_PASSWORD='root'
 sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password password $MYSQL_ROOT_PASSWORD"
 sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
 
-apt-get install -y git imagemagick mysql-server python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
+apt-get install -y git imagemagick mysql-server-5.6 python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
 gem install bundler
 add-apt-repository ppa:fcwu-tw/ppa
 apt-get update

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ apt-get update
 add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty universe'
 export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set password dialogue
 export MYSQL_ROOT_PASSWORD='root'
-sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password password $MYSQL_ROOT_PASSWORD"
-sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
+sudo debconf-set-selections <<< "mysql-server-5.6 mysql-server/root_password password $MYSQL_ROOT_PASSWORD"
+sudo debconf-set-selections <<< "mysql-server-5.6 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
 
 apt-get install -y git imagemagick mysql-server-5.6 python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
 gem install bundler

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,10 @@ update-locale LC_ALL=en_US.utf8
 
 apt-get update
 export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set password dialogue
+export MYSQL_ROOT_PASSWORD='root'
+sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password password $MYSQL_ROOT_PASSWORD"
+sudo debconf-set-selections <<< "mysql-server-5.7 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
+
 apt-get install -y git imagemagick mysql-server python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
 gem install bundler
 add-apt-repository ppa:fcwu-tw/ppa


### PR DESCRIPTION
This PR will bring the new and shiny Ubuntu Xenial to our development environment. It also adjusts the install script a little bit to incorporate changes which mostly affect MySQL.

**MySQL Password:**
After installation MySQL sets a random root password, which can be obtained from the log file. Since that's not very handy for an automated installation, we tell it to use a predefined password instead.

**MySQL version**:
As you may notice, we do not install the latest MySQL version here but 5.6. The reason for that change is that MySQL 5.7 introduces breaking changes when it comes to `GEOMETRY` data. Until we've got a fix for that we stick with 5.6. 

Also we can now install Ruby and Node.js from the offical apt repositories since they have just the versions of both software we need. So we can get rid of custom apt repositories here.
