### PR TITLE
Use nodejs-legacy for the node binary so cap is happy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,7 @@
 # Error out immediately if we get any errors, so we know things failed.
 set -e
 
-  #statements
-#Set locale to en_US.utf8. Needed for a successful capistrano deployment
+#Set locale to en_US.utf8. Needed for a successful capistrano deployment.
 update-locale LC_ALL=en_US.utf8
 
 apt-get update
@@ -17,10 +16,12 @@ add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty universe'
 # Update apt once again so it learns about this new repo.
 apt-get update
 
+# Install MySQL 5.6 finally.
 export DEBIAN_FRONTEND=noninteractive #Prevents mysql installer to show set password dialogue
 export MYSQL_ROOT_PASSWORD='root'
 debconf-set-selections <<< "mysql-server-5.6 mysql-server/root_password password $MYSQL_ROOT_PASSWORD"
 debconf-set-selections <<< "mysql-server-5.6 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
 
-apt-get install -y git imagemagick mysql-server-5.6 python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs npm
+# Install the dependencies.
+apt-get install -y git imagemagick mysql-server-5.6 python-software-properties curl build-essential libmysqlclient-dev libxslt-dev libxml2-dev zlib1g-dev libmagick++-dev vim ruby ruby-dev nodejs-legacy npm
 gem install bundler


### PR DESCRIPTION
Ran into this while deploying, it's changed since trusty.
