### PR TITLE
Switch to ssh connection via cable to fix timeouts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(2) do |config|
   config.ssh.forward_agent = true
   config.vm.network "private_network", ip: "192.168.33.10"
    config.vm.provider "virtualbox" do |vb|
+     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
      vb.memory = "2048"
      vb.cpus = 2
    end


### PR DESCRIPTION
This PR is a work around and fixes the issue that vagrant fails to connect to the virtual box due to ssh connection timeouts. Successfully tested with `Ubuntu 16.04 (Bento)`, `Vagrant 1.8.4 &` `Virtualbox Version 5.0.26 r108824`.

**More background infos:**

- https://github.com/chef/bento/issues/688
- https://github.com/chef/bento/issues/682


